### PR TITLE
different flow for edit address

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Introduction 
-This is Rails 7 app that is a demo of using MapBox for address autofill and geocoding. It also includes a simple demo of MapKick to show a map.
+This is Rails 7 app that is a demo of using MapBox for address autofill and geocoding.
+
+It also includes a simple demo of MapKick to show a map.
+
 
 ## Getting Started
 This is a Rails 7 app, I use Ruby 3.1.2 currently. For background the app was created with the following command `rails new mapbox_demo -j esbuild --css tailwind -d postgresql`. 
@@ -63,7 +66,13 @@ If you look at addresses/new you can see it in action working on a real rails fo
 
 ### Issues/Notes
 The MapBox JS added `address_search` to the name of the control it used to search which was line 1 on the address record. This means that when the form was submitted the controller didn't get line_1 as a parameter but an invalid parameter that it rejected. So had to change it slightly from the MapBox demo so that there is an input box called find_address this is one MapBox takes over, and a normal one for line_1, it did mean the stimulus controller has to manually update line_1 in a similar way to the lat/long boxes. 
-_**Overall this method seems to work pretty well for address autofill. There is some work to do regards the edit flow on a form to get that right. **_
+_**Overall this method seems to work pretty well for address autofill. **_
+
+### Editing Addresses
+When you run the demo and edit and Address you entered you will see that the autofill is switched off. 
+It is replaced with a map and option to drag a marker to update the lat/long. This is based on mapbox example [here](https://docs.mapbox.com/mapbox-gl-js/example/drag-a-marker/).
+
+It requires a stimulus controller `map-drag-controller` and a div with id "map" on the page. We reference the appropriate stimulus controllers on the new and edit pages.
 
 ## MapKick Demo
 

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -10,5 +10,8 @@ application.register("hello", HelloController)
 import MapController from "./map_controller"
 application.register("map", MapController)
 
+import MapDragController from "./map_drag_controller"
+application.register("map-drag", MapDragController)
+
 import MapSearchController from "./map_search_controller"
 application.register("map-search", MapSearchController)

--- a/app/javascript/controllers/map_drag_controller.js
+++ b/app/javascript/controllers/map_drag_controller.js
@@ -1,0 +1,41 @@
+import { Controller } from "@hotwired/stimulus"
+import mapboxgl from 'mapbox-gl';
+
+// Connects to data-controller="map-drag"
+export default class extends Controller {
+  static targets = ['latitudeField', 'longitudeField'];
+  static values = { latitude: Number, longitude: Number }
+
+  connect() {
+    mapboxgl.accessToken = metaContent('mapbox_access_token');
+
+    const map = new mapboxgl.Map({
+      container: 'map',
+      // Choose from Mapbox's core styles, or make your own style with Mapbox Studio
+      style: 'mapbox://styles/mapbox/streets-v12',
+      center: [this.longitudeValue, this.latitudeValue],
+      zoom: 15
+    });
+
+    const marker = new mapboxgl.Marker({
+      draggable: true
+    })
+      .setLngLat([this.longitudeValue, this.latitudeValue])
+      .addTo(map);
+
+
+    const dragEndFunc = function () {
+      const lngLat = marker.getLngLat();
+      console.log(`Longitude: ${lngLat.lng}<br />Latitude: ${lngLat.lat}`);
+      this.setLocation(lngLat);
+    }.bind(this)
+
+    marker.on('dragend', dragEndFunc);
+  }
+
+  setLocation(lngLat) {
+    console.log("setLocation", lngLat);
+    this.longitudeFieldTarget.value = lngLat.lng;
+    this.latitudeFieldTarget.value = lngLat.lat;
+  }
+}

--- a/app/views/addresses/_address_form_fields.html.erb
+++ b/app/views/addresses/_address_form_fields.html.erb
@@ -1,0 +1,54 @@
+       <div>
+          <%= form.label :line_1, style: "display: block" %>
+          <%= form.text_field :line_1, class:"w-full", placeholder: "Start typing your address, e.g. 123 Main...", data: { "map-search-target": "line1Field" }  %>
+        </div>
+
+        <div>
+          <%= form.label :line_2, style: "display: block" %>
+          <%= form.text_field :line_2, class:"w-full",  autocomplete: "address-line2"  %>
+        </div>
+
+        <div>
+          <%= form.label :line_3, style: "display: block" %>
+          <%= form.text_field :line_3, class:"w-full",  autocomplete: "address-level3"  %>
+        </div>
+
+        <div>
+          <%= form.label :line_4, style: "display: block" %>
+          <%= form.text_field :line_4, class:"w-full"  %>
+        </div>
+
+        <div>
+          <%= form.label :city, style: "display: block" %>
+          <%= form.text_field :city, class:"w-full",  autocomplete: "address-level2"  %>
+        </div>
+
+        <div>
+          <%= form.label :region, style: "display: block" %>
+          <%= form.text_field :region, class:"w-full",  autocomplete: "address-level1"  %>
+        </div>
+
+        <div>
+          <%= form.label :country, style: "display: block" %>
+          <%= form.text_field :country, class:"w-full",  autocomplete: "country-name"  %>
+        </div>
+
+        <div>
+          <%= form.label :postal_code, style: "display: block" %>
+          <%= form.text_field :postal_code, class:"w-full",  autocomplete: "postal-code"  %>
+        </div>
+
+        <div>
+          <%= form.label :latitude, style: "display: block" %>
+          <%= form.text_field :latitude, class:"w-full", data: { "map-search-target": "latitudeField", "map-drag-target": "latitudeField" }  %>
+        </div>
+
+        <div>
+          <%= form.label :longitude, style: "display: block" %>
+          <%= form.text_field :longitude, class:"w-full", data: { "map-search-target": "longitudeField", "map-drag-target": "longitudeField" }  %>
+        </div>
+
+        <div>
+          <%= form.label :full_address, style: "display: block" %>
+          <%= form.text_field :full_address, class:"w-full"  %>
+        </div>

--- a/app/views/addresses/_form.html.erb
+++ b/app/views/addresses/_form.html.erb
@@ -1,18 +1,10 @@
 
-<div data-controller="map-search">
+
   <div class="grid grid-cols-2 gap-4 w-full">
     <%= form_with(model: address) do |form| %>
-      <% if address.errors.any? %>
-        <div style="color: red">
-          <h2><%= pluralize(address.errors.count, "error") %> prohibited this address from being saved:</h2>
-
-          <ul>
-            <% address.errors.each do |error| %>
-              <li><%= error.full_message %></li>
-            <% end %>
-          </ul>
-        </div>
-      <% end %>
+      <% hide_find_address_on_edit_css = form.object.persisted? ? "hidden" : "" %>
+      <% hide_secondary_inputs_on_new_css = form.object.persisted? ? "" : "hidden" %>
+      <%= render "form_errors", address: address %>
       <div>
         <%= form.label :customer_id, style: "display: block" %>
         <%= form.select :customer_id,Customer.all.map { |c| [c.name, c.id] }, class:"w-full"  %>
@@ -23,70 +15,17 @@
         <%= form.text_field :attention, class:"w-full" %>
       </div>
 
-      <div>
+      <div class="<%= hide_find_address_on_edit_css %>">
         <%= form.label :find_address, style: "display: block" %>
         <%= form.text_field :find_address, class:"w-full", placeholder: "Start typing your address, e.g. 123 Main...", autocomplete:"address-line1"  %>
       </div>
 
-      <div data-map-search-target="manualEntry">
+      <div data-map-search-target="manualEntry" class="<%= hide_find_address_on_edit_css %>">
         <button class="text-gray-900 underline text-blue-600" data-action="click->map-search#openManualEntry">Enter an address manually</button>
       </div>
 
-      <div data-map-search-target="secondaryInputs" class="grid grid-cols-1 hidden">
-        <div>
-          <%= form.label :line_1, style: "display: block" %>
-          <%= form.text_field :line_1, class:"w-full", placeholder: "Start typing your address, e.g. 123 Main...", data: { "map-search-target": "line1Field" }  %>
-        </div>
-
-        <div>
-          <%= form.label :line_2, style: "display: block" %>
-          <%= form.text_field :line_2, class:"w-full",  autocomplete: "address-line2"  %>
-        </div>
-
-        <div>
-          <%= form.label :line_3, style: "display: block" %>
-          <%= form.text_field :line_3, class:"w-full",  autocomplete: "address-level3"  %>
-        </div>
-
-        <div>
-          <%= form.label :line_4, style: "display: block" %>
-          <%= form.text_field :line_4, class:"w-full"  %>
-        </div>
-
-        <div>
-          <%= form.label :city, style: "display: block" %>
-          <%= form.text_field :city, class:"w-full",  autocomplete: "address-level2"  %>
-        </div>
-
-        <div>
-          <%= form.label :region, style: "display: block" %>
-          <%= form.text_field :region, class:"w-full",  autocomplete: "address-level1"  %>
-        </div>
-
-        <div>
-          <%= form.label :country, style: "display: block" %>
-          <%= form.text_field :country, class:"w-full",  autocomplete: "country-name"  %>
-        </div>
-
-        <div>
-          <%= form.label :postal_code, style: "display: block" %>
-          <%= form.text_field :postal_code, class:"w-full",  autocomplete: "postal-code"  %>
-        </div>
-
-        <div>
-          <%= form.label :latitude, style: "display: block" %>
-          <%= form.text_field :latitude, class:"w-full", data: { "map-search-target": "latitudeField" }  %>
-        </div>
-
-        <div>
-          <%= form.label :longitude, style: "display: block" %>
-          <%= form.text_field :longitude, class:"w-full", data: { "map-search-target": "longitudeField" }  %>
-        </div>
-
-        <div>
-          <%= form.label :full_address, style: "display: block" %>
-          <%= form.text_field :full_address, class:"w-full"  %>
-        </div>
+      <div data-map-search-target="secondaryInputs" class="grid grid-cols-1 <%= hide_secondary_inputs_on_new_css %>">
+        <%= render "address_form_fields", form: form %>
       </div>
       <div>
         <%= form.submit %>
@@ -94,7 +33,10 @@
     <% end %>
     <div class="">
     <!-- Visual confirmation map -->
-      <div data-map-search-target="minimapContainer" id="minimap-container" class="none w-full h-96 mb-6"></div>
+      <% if address.persisted? %>
+        <div id="map" class="none w-full h-96 mb-6"></div>
+      <% else %>
+        <div data-map-search-target="minimapContainer" id="minimap-container" class="none w-full h-96 mb-6"></div>
+      <% end %>
     </div>    
   </div>
-</div>

--- a/app/views/addresses/_form_errors.html.erb
+++ b/app/views/addresses/_form_errors.html.erb
@@ -1,0 +1,11 @@
+  <% if address.errors.any? %>
+    <div style="color: red">
+      <h2><%= pluralize(address.errors.count, "error") %> prohibited this address from being saved:</h2>
+
+      <ul>
+        <% address.errors.each do |error| %>
+          <li><%= error.full_message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>

--- a/app/views/addresses/edit.html.erb
+++ b/app/views/addresses/edit.html.erb
@@ -1,6 +1,8 @@
 <h1>Editing address</h1>
 
-<%= render "form", address: @address %>
+<div data-controller="map-drag" data-map-drag-longitude-value="<%= @address.longitude || 0 %>", data-map-drag-latitude-value="<%= @address.latitude || 0 %>">
+  <%= render "form", address: @address %>
+</div>
 
 <br>
 

--- a/app/views/addresses/new.html.erb
+++ b/app/views/addresses/new.html.erb
@@ -1,6 +1,8 @@
 <h1>New address</h1>
 
-<%= render "form", address: @address %>
+<div data-controller="map-search">
+  <%= render "form", address: @address %>
+</div>
 
 <br>
 


### PR DESCRIPTION
I wanted a different flow on edit address vs new address. Edit will not have autofill, it will have a map and allow you to drag the marker to get different lat/long but the rest will just be regular form. 

This is dependent on adding `yarn add mapbox-gl` and we have a new stimulus controller `map-drag-controller` that does the map and updates the lat/long if the user drags them around.

Using the fact there are New and Edit templates to control which controller is used if it is new we use the map-search controller and show the fields for autofill other wise use map-drag controller. The form etc, bit messy with hidden stuff but get the gist of it.